### PR TITLE
Bugfix: Fixed batch splitting.

### DIFF
--- a/train_deep_sdf.py
+++ b/train_deep_sdf.py
@@ -480,6 +480,8 @@ def main_function(experiment_directory, continue_from, batch_split):
 
             _subbatch += 1
             if _subbatch == batch_split:
+                _subbatch = 0
+            
                 loss_log.append(batch_loss)
 
                 if grad_clip is not None:

--- a/train_deep_sdf.py
+++ b/train_deep_sdf.py
@@ -430,65 +430,68 @@ def main_function(experiment_directory, continue_from, batch_split):
 
         adjust_learning_rate(lr_schedules, optimizer_all, epoch)
 
+        _subbatch = 0
         for sdf_data, indices in sdf_loader:
 
-            batch_loss = 0.0
+            if _subbatch == 0:
+                batch_loss = 0.0
 
-            optimizer_all.zero_grad()
+                optimizer_all.zero_grad()
 
-            for _subbatch in range(batch_split):
+            # Process the input datag
+            latent_inputs = torch.zeros(0).cuda()
+            sdf_data.requires_grad = False
 
-                # Process the input datag
-                latent_inputs = torch.zeros(0).cuda()
-                sdf_data.requires_grad = False
+            sdf_data = (sdf_data.cuda()).reshape(
+                num_samp_per_scene * scene_per_subbatch, 4
+            )
+            xyz = sdf_data[:, 0:3]
+            sdf_gt = sdf_data[:, 3].unsqueeze(1)
+            for ind in indices.numpy():
+                latent_ind = lat_vecs[ind]
+                latent_repeat = latent_ind.expand(num_samp_per_scene, -1)
+                latent_inputs = torch.cat([latent_inputs, latent_repeat], 0)
+            inputs = torch.cat([latent_inputs, xyz], 1)
 
-                sdf_data = (sdf_data.cuda()).reshape(
-                    num_samp_per_scene * scene_per_subbatch, 4
+            if enforce_minmax:
+                sdf_gt = deep_sdf.utils.threshold_min_max(sdf_gt, min_vec, max_vec)
+
+            if latent_size == 0:
+                inputs = xyz
+
+            # NN optimization
+
+            pred_sdf = decoder(inputs)
+
+            if enforce_minmax:
+                pred_sdf = deep_sdf.utils.threshold_min_max(
+                    pred_sdf, min_vec, max_vec
                 )
-                xyz = sdf_data[:, 0:3]
-                sdf_gt = sdf_data[:, 3].unsqueeze(1)
-                for ind in indices.numpy():
-                    latent_ind = lat_vecs[ind]
-                    latent_repeat = latent_ind.expand(num_samp_per_scene, -1)
-                    latent_inputs = torch.cat([latent_inputs, latent_repeat], 0)
-                inputs = torch.cat([latent_inputs, xyz], 1)
 
-                if enforce_minmax:
-                    sdf_gt = deep_sdf.utils.threshold_min_max(sdf_gt, min_vec, max_vec)
+            loss = loss_l1(pred_sdf, sdf_gt)/batch_split
 
-                if latent_size == 0:
-                    inputs = xyz
+            if do_code_regularization:
+                l2_size_loss = latent_size_regul(lat_vecs, indices.numpy())/batch_split
+                loss += code_reg_lambda * min(1, epoch / 100) * l2_size_loss
 
-                # NN optimization
+            loss.backward()
 
-                pred_sdf = decoder(inputs)
+            batch_loss += loss.item()
 
-                if enforce_minmax:
-                    pred_sdf = deep_sdf.utils.threshold_min_max(
-                        pred_sdf, min_vec, max_vec
-                    )
+            _subbatch += 1
+            if _subbatch == batch_split:
+                _subbatch = 0
+                loss_log.append(batch_loss)
 
-                loss = loss_l1(pred_sdf, sdf_gt)/batch_split
+                if grad_clip is not None:
 
-                if do_code_regularization:
-                    l2_size_loss = latent_size_regul(lat_vecs, indices.numpy())/batch_split
-                    loss += code_reg_lambda * min(1, epoch / 100) * l2_size_loss
+                    torch.nn.utils.clip_grad_norm_(decoder.parameters(), grad_clip)
 
-                loss.backward()
+                optimizer_all.step()
 
-                batch_loss += loss.item()
-
-            loss_log.append(batch_loss)
-
-            if grad_clip is not None:
-
-                torch.nn.utils.clip_grad_norm_(decoder.parameters(), grad_clip)
-
-            optimizer_all.step()
-
-            # Project latent vectors onto sphere
-            if code_bound is not None:
-                deep_sdf.utils.project_vecs_onto_sphere(lat_vecs, code_bound)
+                # Project latent vectors onto sphere
+                if code_bound is not None:
+                    deep_sdf.utils.project_vecs_onto_sphere(lat_vecs, code_bound)
 
         end = time.time()
 

--- a/train_deep_sdf.py
+++ b/train_deep_sdf.py
@@ -430,65 +430,67 @@ def main_function(experiment_directory, continue_from, batch_split):
 
         adjust_learning_rate(lr_schedules, optimizer_all, epoch)
 
+        _subbatch = 0
         for sdf_data, indices in sdf_loader:
 
-            batch_loss = 0.0
+            if _subbatch == 0:
+                batch_loss = 0.0
 
-            optimizer_all.zero_grad()
+                optimizer_all.zero_grad()
 
-            for _subbatch in range(batch_split):
+            # Process the input datag
+            latent_inputs = torch.zeros(0).cuda()
+            sdf_data.requires_grad = False
 
-                # Process the input datag
-                latent_inputs = torch.zeros(0).cuda()
-                sdf_data.requires_grad = False
+            sdf_data = (sdf_data.cuda()).reshape(
+                num_samp_per_scene * scene_per_subbatch, 4
+            )
+            xyz = sdf_data[:, 0:3]
+            sdf_gt = sdf_data[:, 3].unsqueeze(1)
+            for ind in indices.numpy():
+                latent_ind = lat_vecs[ind]
+                latent_repeat = latent_ind.expand(num_samp_per_scene, -1)
+                latent_inputs = torch.cat([latent_inputs, latent_repeat], 0)
+            inputs = torch.cat([latent_inputs, xyz], 1)
 
-                sdf_data = (sdf_data.cuda()).reshape(
-                    num_samp_per_scene * scene_per_subbatch, 4
+            if enforce_minmax:
+                sdf_gt = deep_sdf.utils.threshold_min_max(sdf_gt, min_vec, max_vec)
+
+            if latent_size == 0:
+                inputs = xyz
+
+            # NN optimization
+
+            pred_sdf = decoder(inputs)
+
+            if enforce_minmax:
+                pred_sdf = deep_sdf.utils.threshold_min_max(
+                    pred_sdf, min_vec, max_vec
                 )
-                xyz = sdf_data[:, 0:3]
-                sdf_gt = sdf_data[:, 3].unsqueeze(1)
-                for ind in indices.numpy():
-                    latent_ind = lat_vecs[ind]
-                    latent_repeat = latent_ind.expand(num_samp_per_scene, -1)
-                    latent_inputs = torch.cat([latent_inputs, latent_repeat], 0)
-                inputs = torch.cat([latent_inputs, xyz], 1)
 
-                if enforce_minmax:
-                    sdf_gt = deep_sdf.utils.threshold_min_max(sdf_gt, min_vec, max_vec)
+            loss = loss_l1(pred_sdf, sdf_gt)
 
-                if latent_size == 0:
-                    inputs = xyz
+            if do_code_regularization:
+                l2_size_loss = latent_size_regul(lat_vecs, indices.numpy())
+                loss += code_reg_lambda * min(1, epoch / 100) * l2_size_loss
 
-                # NN optimization
+            loss.backward()
 
-                pred_sdf = decoder(inputs)
+            batch_loss += loss.item()
 
-                if enforce_minmax:
-                    pred_sdf = deep_sdf.utils.threshold_min_max(
-                        pred_sdf, min_vec, max_vec
-                    )
+            _subbatch += 1
+            if _subbatch == batch_split:
+                loss_log.append(batch_loss)
 
-                loss = loss_l1(pred_sdf, sdf_gt)
+                if grad_clip is not None:
 
-                if do_code_regularization:
-                    l2_size_loss = latent_size_regul(lat_vecs, indices.numpy())
-                    loss += code_reg_lambda * min(1, epoch / 100) * l2_size_loss
+                    torch.nn.utils.clip_grad_norm_(decoder.parameters(), grad_clip)
 
-                loss.backward()
+                optimizer_all.step()
 
-                batch_loss += loss.item()
-
-            loss_log.append(batch_loss)
-
-            if grad_clip is not None:
-
-                torch.nn.utils.clip_grad_norm_(decoder.parameters(), grad_clip)
-
-            optimizer_all.step()
-
-            # Project latent vectors onto sphere
-            if code_bound is not None:
-                deep_sdf.utils.project_vecs_onto_sphere(lat_vecs, code_bound)
+                # Project latent vectors onto sphere
+                if code_bound is not None:
+                    deep_sdf.utils.project_vecs_onto_sphere(lat_vecs, code_bound)
 
         end = time.time()
 

--- a/train_deep_sdf.py
+++ b/train_deep_sdf.py
@@ -430,69 +430,65 @@ def main_function(experiment_directory, continue_from, batch_split):
 
         adjust_learning_rate(lr_schedules, optimizer_all, epoch)
 
-        _subbatch = 0
         for sdf_data, indices in sdf_loader:
 
-            if _subbatch == 0:
-                batch_loss = 0.0
+            batch_loss = 0.0
 
-                optimizer_all.zero_grad()
+            optimizer_all.zero_grad()
 
-            # Process the input datag
-            latent_inputs = torch.zeros(0).cuda()
-            sdf_data.requires_grad = False
+            for _subbatch in range(batch_split):
 
-            sdf_data = (sdf_data.cuda()).reshape(
-                num_samp_per_scene * scene_per_subbatch, 4
-            )
-            xyz = sdf_data[:, 0:3]
-            sdf_gt = sdf_data[:, 3].unsqueeze(1)
-            for ind in indices.numpy():
-                latent_ind = lat_vecs[ind]
-                latent_repeat = latent_ind.expand(num_samp_per_scene, -1)
-                latent_inputs = torch.cat([latent_inputs, latent_repeat], 0)
-            inputs = torch.cat([latent_inputs, xyz], 1)
+                # Process the input datag
+                latent_inputs = torch.zeros(0).cuda()
+                sdf_data.requires_grad = False
 
-            if enforce_minmax:
-                sdf_gt = deep_sdf.utils.threshold_min_max(sdf_gt, min_vec, max_vec)
-
-            if latent_size == 0:
-                inputs = xyz
-
-            # NN optimization
-
-            pred_sdf = decoder(inputs)
-
-            if enforce_minmax:
-                pred_sdf = deep_sdf.utils.threshold_min_max(
-                    pred_sdf, min_vec, max_vec
+                sdf_data = (sdf_data.cuda()).reshape(
+                    num_samp_per_scene * scene_per_subbatch, 4
                 )
+                xyz = sdf_data[:, 0:3]
+                sdf_gt = sdf_data[:, 3].unsqueeze(1)
+                for ind in indices.numpy():
+                    latent_ind = lat_vecs[ind]
+                    latent_repeat = latent_ind.expand(num_samp_per_scene, -1)
+                    latent_inputs = torch.cat([latent_inputs, latent_repeat], 0)
+                inputs = torch.cat([latent_inputs, xyz], 1)
 
-            loss = loss_l1(pred_sdf, sdf_gt)
+                if enforce_minmax:
+                    sdf_gt = deep_sdf.utils.threshold_min_max(sdf_gt, min_vec, max_vec)
 
-            if do_code_regularization:
-                l2_size_loss = latent_size_regul(lat_vecs, indices.numpy())
-                loss += code_reg_lambda * min(1, epoch / 100) * l2_size_loss
+                if latent_size == 0:
+                    inputs = xyz
 
-            loss.backward()
+                # NN optimization
 
-            batch_loss += loss.item()
+                pred_sdf = decoder(inputs)
 
-            _subbatch += 1
-            if _subbatch == batch_split:
-                _subbatch = 0
-            
-                loss_log.append(batch_loss)
+                if enforce_minmax:
+                    pred_sdf = deep_sdf.utils.threshold_min_max(
+                        pred_sdf, min_vec, max_vec
+                    )
 
-                if grad_clip is not None:
+                loss = loss_l1(pred_sdf, sdf_gt)/batch_split
 
-                    torch.nn.utils.clip_grad_norm_(decoder.parameters(), grad_clip)
+                if do_code_regularization:
+                    l2_size_loss = latent_size_regul(lat_vecs, indices.numpy())/batch_split
+                    loss += code_reg_lambda * min(1, epoch / 100) * l2_size_loss
 
-                optimizer_all.step()
+                loss.backward()
 
-                # Project latent vectors onto sphere
-                if code_bound is not None:
-                    deep_sdf.utils.project_vecs_onto_sphere(lat_vecs, code_bound)
+                batch_loss += loss.item()
+
+            loss_log.append(batch_loss)
+
+            if grad_clip is not None:
+
+                torch.nn.utils.clip_grad_norm_(decoder.parameters(), grad_clip)
+
+            optimizer_all.step()
+
+            # Project latent vectors onto sphere
+            if code_bound is not None:
+                deep_sdf.utils.project_vecs_onto_sphere(lat_vecs, code_bound)
 
         end = time.time()
 


### PR DESCRIPTION
The inner for loop (_subbatch) had no effect -- it always used the same subbatch. This can be verified by printing sdf_data or loss in every iteration of _subbatch. The outer for loop generates a subbatch (sdf_data) and this subbatch is then re-used _batch_split_ many times in the inner for loop.

I'm new to Pytorch, so maybe I'm using it wrong.