### PR TITLE
Allow preprocess_data.py to be run from outside the DeepSDF directory

### DIFF
--- a/deep_sdf/data.py
+++ b/deep_sdf/data.py
@@ -50,7 +50,7 @@ def find_mesh_in_directory(shape_dir):
         glob.iglob(shape_dir + "/*.obj")
     )
     if len(mesh_filenames) == 0:
-        return NoMeshFileError()
+        raise NoMeshFileError()
     elif len(mesh_filenames) > 1:
         raise MultipleMeshFileError()
     return mesh_filenames[0]

--- a/preprocess_data.py
+++ b/preprocess_data.py
@@ -151,12 +151,13 @@ if __name__ == "__main__":
 
     additional_general_args = []
 
+    deepsdf_dir = os.path.dirname(os.path.abspath(__file__))
     if args.surface_sampling:
-        executable = "bin/SampleVisibleMeshSurface"
+        executable = os.path.join(deepsdf_dir, "bin/SampleVisibleMeshSurface")
         subdir = ws.surface_samples_subdir
         extension = ".ply"
     else:
-        executable = "bin/PreprocessMesh"
+        executable = os.path.join(deepsdf_dir, "bin/PreprocessMesh")
         subdir = ws.sdf_samples_subdir
         extension = ".npz"
 


### PR DESCRIPTION
When the script `preprocess_data.py` is executed from outside of the DeepSDF directory, C++ binaries are not found and the program fails silently (no errors reported).

I suspect that this is the issue for most people reporting https://github.com/facebookresearch/DeepSDF/issues/19

This commit fixes the issue.