### PR TITLE
Remove rounding errors in create_mesh

### DIFF
--- a/deep_sdf/mesh.py
+++ b/deep_sdf/mesh.py
@@ -29,8 +29,8 @@ def create_mesh(
     # transform first 3 columns
     # to be the x, y, z index
     samples[:, 2] = overall_index % N
-    samples[:, 1] = (overall_index.long() / N) % N
-    samples[:, 0] = ((overall_index.long() / N) / N) % N
+    samples[:, 1] = (overall_index // N) % N
+    samples[:, 0] = ((overall_index // N) // N) % N
 
     # transform first 3 columns
     # to be the x, y, z coordinate


### PR DESCRIPTION
In the current code for sampling a grid of SDF values, there is a rounding error in the computation of the regularly spaced 3D coordinates of the grid.
To exemplify my point, for `N=256` (default), the (x,y,z)=(1,1,1) edge of the bounding box instead has coordinates
```
>>> samples[-1, :]
tensor([1.0078, 1.0078, 1.0000, 0.0000])
```

This error does not only affect coordinates on the cube's boundaries, but the whole volume.
I propose to properly carry integer division, which now yields:
```
>>> samples[-1, :]
tensor([1., 1., 1., 0.])
```

Despite the error in 3D coordinates being small, I have found this fix to improve 3D reconstruction metrics quite a bit (~5% on my task).